### PR TITLE
Include Linenoise

### DIFF
--- a/META.info
+++ b/META.info
@@ -21,6 +21,7 @@
         "Bailador",
         "DBIish",
         "URI",
+        "Linenoise",
         "LWP::Simple",
         "JSON::RPC",
         "Pod::To::HTML",


### PR DESCRIPTION
Rakudo no longer provides Linenoise, so bundle it with Task::Star as
Perl6 REPL is of little use otherwise.